### PR TITLE
fix version requirement to use correct syntax

### DIFF
--- a/t/lib/TestApp.pm
+++ b/t/lib/TestApp.pm
@@ -3,7 +3,7 @@ package TestApp;
 use strict;
 use warnings;
 
-use Catalyst::Runtime '5.70';
+use Catalyst::Runtime 5.70;
 
 use parent qw/Catalyst/;
 


### PR DESCRIPTION
Version numbers on a use line need to be unquoted to be handled properly. When they are quoted, they are passed in import instead. Part versions of perl ignored these arguments, but future versions are intending to throw errors for arguments given to an undefined import method.